### PR TITLE
docs: update architecture and usage docs for M14 output layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,13 @@ Patterns confirmed across M2–M4 that must be followed in all ingestion modules
 
 Copy `.env.example` to `.env` for local dev. Required vars: `DATABASE_URL`, `EDGAR_USER_AGENT`. See `.env.example` for all options.
 
+## Documentation Conventions
+
+Two docs live in `docs/` and must be kept in sync with the code:
+
+- **`docs/architecture.md`** — Update when the system *design* changes: new modules, changed data flows, new DB patterns, algorithm details, design decisions. If you change how a component works internally, update the relevant architecture section.
+- **`docs/usage.md`** — Update when *how operators use the system* changes: new or changed function signatures, new parameters, new CLI commands, new Docker workflows, new output formats. Each public function exposed to operators should have a usage example.
+
 ## Common Commands
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,38 +261,69 @@ This ensures zero duplicate alerts per entity per threshold within any time peri
 
 ## 7. Output Layer (M14)
 
-*(Planned — not yet implemented)*
-
-M14 uses a **static site export** pattern. After the daily scoring run, a single export function reads the completed `alert_scores`, `entities`, and `signals` tables and writes a self-contained directory of JSON files. These files are uploaded to S3/CDN (or GitHub Pages) and require no live database at serve time.
+M14 uses a **static site export** pattern. After the daily scoring run, `export_static_site` reads the completed `alert_scores`, `entities`, and `signals` tables and writes a self-contained directory of files. The output can be uploaded to S3/CDN (or GitHub Pages) or opened directly from the filesystem — no live database is needed at serve time.
 
 ### Static Data Export
 
-`export_static_site(output_dir, *, db)` writes:
+`export_static_site(output_dir, *, db)` writes paired `.json` + `.js` companion files for every dataset:
 
 ```
 {output_dir}/
-├── meta.json                    # exported_at, entity_count, alert_count
-├── alerts.json                  # all alerts: critical → elevated → watch, date desc
-├── entities.json                # all entity summaries with current scores
-└── entities/
-    └── {entity_id}.json         # per-entity: score history + component breakdown + evidence
+├── meta.json          # exported_at, entity_count, alert_count, version
+├── meta.js            # window.CAM_META = {...};
+├── alerts.json        # all alerts sorted: critical → elevated → watch, date desc
+├── alerts.js          # window.CAM_ALERTS = [...];
+├── entities.json      # all entity summaries with current scores
+├── entities.js        # window.CAM_ENTITIES = [...];
+├── entities/
+│   ├── {id}.json      # per-entity: score history, component breakdown, top evidence
+│   └── {id}.js        # window.CAM_ENTITY = {...};
+├── index.html         # alert feed dashboard
+├── entity.html        # entity detail (uses ?id= URL param)
+└── industries.html    # entities grouped by 2-digit NAICS
 ```
 
-Export is idempotent — files are written atomically (temp file → rename) so partial exports are never visible.
+**Why two file formats?** Browsers block `fetch()` from `file://` URIs (same-origin policy), but `<script src="...">` is unrestricted. The `.js` companion files assign data to `window.CAM_*` globals so the HTML dashboards work whether opened from a CDN or double-clicked from a desktop folder.
+
+**Atomic writes:** Every file is written via a sibling `.tmp` file then renamed to the target, so readers never observe a partial file.
+
+**Stale file cleanup:** After writing the current entity set, any `entities/{id}.json` or `entities/{id}.js` files whose stem does not match a current entity ID are deleted. This ensures removed entities don't accumulate in the output directory.
+
+**Bounded DB queries:** History and evidence data are fetched using `ROW_NUMBER() OVER (PARTITION BY entity_id ORDER BY ...)` window functions. The database returns at most `_HISTORY_LIMIT = 90` history rows and `_EVIDENCE_LIMIT = 5` evidence rows per entity, regardless of table size.
 
 ### Static HTML Dashboard
 
-Minimal vanilla-JS pages that load exported JSON via `fetch()`. No build step, no framework. Renders correctly from `file://` URI or any CDN.
+Three minimal vanilla-JS pages, no build step, no framework:
 
-Priority pages:
+1. **index.html** — Alert feed sorted by severity (critical first), with inline filter
+2. **entity.html?id={uuid}** — Score timeline, component breakdown, top evidence signals
+3. **industries.html** — All entities grouped by 2-digit NAICS, sorted by average score
 
-1. **index.html** — Alert feed sorted by severity (critical first)
-2. **entity.html?id={uuid}** — Score timeline, component breakdown, evidence links
-3. **industries.html** — All entities grouped by 2-digit NAICS, sorted by score
+Each page uses a `loadScript(src)` helper that inserts a `<script>` tag and resolves a Promise on load, then reads data from the corresponding `window.CAM_*` global. This replaces `fetch()` and works from `file://` URIs without an HTTP server.
 
 ### Weekly Digest
 
-`export_digest(since_date, *, db)` returns a plaintext email body. The caller is responsible for SMTP delivery (configured via `cam/config.py`).
+`export_digest(since_date, *, db)` returns a plaintext email body summarising:
+
+- All critical and elevated alerts with `score_date >= since_date`, including up to two top evidence snippets (truncated to 120 characters) per entity
+- Top 5 sectors (2-digit NAICS) by average composite score, restricted to sectors with ≥ 3 entities
+
+The caller is responsible for SMTP delivery — this function only produces the body string.
+
+### Score Composition
+
+The composite score used for alert levels is a weighted sum of six signal components:
+
+| Component                | Weight | Source Module |
+|--------------------------|--------|---------------|
+| Cross-agency aggregate   | 35%    | M6            |
+| Risk language (10-K NLP) | 20%    | M7            |
+| Earnings call divergence | 15%    | M8            |
+| Proxy escalation signals | 15%    | M9            |
+| Merger vertical risk     | 10%    | M10           |
+| PE ownership flag        | 5%     | M12           |
+
+Missing components default to **0.0** — the scorer degrades gracefully if upstream modules have not yet produced signals for an entity.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,20 +1,23 @@
 # Corporate Accountability Monitor — Usage Guide
 
-This guide explains how to run the CAM pipeline, score entities, and interpret alerts. The intended audience is analysts, researchers, and engineers who operate the system day-to-day.
+This guide explains how to run the CAM pipeline, score entities, export the dashboard, and interpret alerts. The intended audience is analysts, researchers, and engineers who operate the system day-to-day.
 
 ---
 
 ## Table of Contents
 
 1. [Quick Start](#1-quick-start)
-2. [Ingesting Regulatory Data](#2-ingesting-regulatory-data)
-3. [Flagging PE-Owned Entities](#3-flagging-pe-owned-entities)
-4. [Running Daily Alert Scoring](#4-running-daily-alert-scoring)
-5. [Interpreting Alert Levels](#5-interpreting-alert-levels)
-6. [Generating Alerts for a Single Entity](#6-generating-alerts-for-a-single-entity)
-7. [Industry Benchmarking (PE vs. Non-PE)](#7-industry-benchmarking-pe-vs-non-pe)
-8. [Environment Setup](#8-environment-setup)
-9. [Running Tests](#9-running-tests)
+2. [Using Docker](#2-using-docker)
+3. [Ingesting Regulatory Data](#3-ingesting-regulatory-data)
+4. [Flagging PE-Owned Entities](#4-flagging-pe-owned-entities)
+5. [Running Daily Alert Scoring](#5-running-daily-alert-scoring)
+6. [Exporting the Static Site Dashboard](#6-exporting-the-static-site-dashboard)
+7. [Generating the Weekly Email Digest](#7-generating-the-weekly-email-digest)
+8. [Interpreting Alert Levels](#8-interpreting-alert-levels)
+9. [Generating Alerts for a Single Entity](#9-generating-alerts-for-a-single-entity)
+10. [Industry Benchmarking (PE vs. Non-PE)](#10-industry-benchmarking-pe-vs-non-pe)
+11. [Environment Setup](#11-environment-setup)
+12. [Running Tests](#12-running-tests)
 
 ---
 
@@ -27,7 +30,7 @@ docker-compose up -d
 # Apply database migrations
 DATABASE_URL=postgresql://cam:cam@localhost:5432/cam alembic upgrade head
 
-# Ingest all WARN Act notices (all 50 states)
+# Ingest WARN Act notices (all 50 states)
 PYTHONPATH=. python -c "
 from cam.db.session import get_session
 from cam.ingestion.warn import ingest_all_states
@@ -45,11 +48,89 @@ with get_session() as db:
     scores = run_daily_scoring(score_date=date.today(), db=db)
     print(f'Scored {len(scores)} entities')
 "
+
+# Export the static site dashboard
+PYTHONPATH=. python -c "
+from cam.db.session import get_session
+from cam.output import export_static_site
+with get_session() as db:
+    result = export_static_site('/tmp/cam-site', db=db)
+    print(result)
+"
+# Open the dashboard: open /tmp/cam-site/index.html
 ```
 
 ---
 
-## 2. Ingesting Regulatory Data
+## 2. Using Docker
+
+The `docker-compose.yml` starts all required infrastructure services and the Celery worker and beat scheduler.
+
+### Start all services
+
+```bash
+# Build the CAM image and start Postgres, Redis, MinIO, worker, and beat
+docker-compose up -d
+
+# Check that all services are healthy
+docker-compose ps
+```
+
+### Run one-off pipeline commands inside Docker
+
+```bash
+# Apply migrations via the worker container
+docker-compose run --rm worker alembic upgrade head
+
+# Ingest WARN Act data
+docker-compose run --rm worker python -c "
+from cam.db.session import get_session
+from cam.ingestion.warn import ingest_all_states
+with get_session() as db:
+    print(ingest_all_states(db=db))
+"
+
+# Run daily scoring
+docker-compose run --rm worker python -c "
+from datetime import date
+from cam.db.session import get_session
+from cam.alerts.scorer import run_daily_scoring
+with get_session() as db:
+    scores = run_daily_scoring(score_date=date.today(), db=db)
+    print(f'Scored {len(scores)} entities')
+"
+
+# Export the dashboard to a host-mounted path
+docker-compose run --rm -v /tmp/cam-site:/out worker python -c "
+from cam.db.session import get_session
+from cam.output import export_static_site
+with get_session() as db:
+    print(export_static_site('/out', db=db))
+"
+```
+
+### Worker and Beat
+
+The `worker` service runs the Celery worker; `beat` runs the Celery beat scheduler for recurring tasks. Environment variables `DATABASE_URL`, `REDIS_URL`, and `S3_ENDPOINT` are automatically set to the Docker service URLs — no `.env` editing is needed for the default Docker setup.
+
+```bash
+# Tail worker logs
+docker-compose logs -f worker
+
+# Restart a single service
+docker-compose restart worker
+```
+
+### Build a fresh image after code changes
+
+```bash
+docker-compose build
+docker-compose up -d
+```
+
+---
+
+## 3. Ingesting Regulatory Data
 
 Each ingestion module reads from a government data source and writes to the `events` table. All functions are **idempotent** — running them twice produces the same database state.
 
@@ -111,7 +192,7 @@ with get_session() as db:
 
 ---
 
-## 3. Flagging PE-Owned Entities
+## 4. Flagging PE-Owned Entities
 
 CAM tracks private equity ownership through the `Signal` table. Use `flag_pe_entity_for_monitoring` to mark an entity as PE-owned:
 
@@ -137,7 +218,7 @@ Once flagged, the entity's `pe_warn_flag` component (5% weight) activates in the
 
 ---
 
-## 4. Running Daily Alert Scoring
+## 5. Running Daily Alert Scoring
 
 The `run_daily_scoring` function scores **all entities** that have at least one `Signal` record. It writes composite scores to the `alert_scores` table and commits once at the end.
 
@@ -167,35 +248,127 @@ This is also exposed as a **Celery task** — see `cam/tasks.py`.
 
 ---
 
-## 5. Interpreting Alert Levels
+## 6. Exporting the Static Site Dashboard
 
-| Level    | Threshold | Meaning                                     | Recommended Action                    |
-|----------|-----------|---------------------------------------------|---------------------------------------|
-| `watch`  | ≥ 0.40    | Worth monitoring; no immediate action       | Flag for weekly review                |
-| `elevated` | ≥ 0.65  | Elevated risk; analyst review warranted     | Assign analyst; cross-check filings   |
-| `critical` | ≥ 0.80  | Significant risk; regulatory action likely  | Escalate; consider regulatory referral|
-| *(none)* | < 0.40    | Within normal operating range               | No action                             |
+`export_static_site` reads the current `alert_scores`, `entities`, and `signals` tables and writes a self-contained directory of files. The output can be hosted anywhere (S3, GitHub Pages, Netlify) or opened directly from the filesystem — no web server is required.
 
-Alerts only fire when the level **increases**. An entity that stays at `watch` for three weeks in a row generates exactly **one** alert — on the day it first crossed the 0.40 threshold.
+```python
+from cam.db.session import get_session
+from cam.output import export_static_site
 
-### Score Composition
+with get_session() as db:
+    result = export_static_site("/path/to/output", db=db)
 
-The composite score is a weighted sum of six signal components:
+# result = {"entities": 312, "alerts": 47, "files_written": 643}
+print(result)
+```
 
-| Component                | Weight | Source Module |
-|--------------------------|--------|---------------|
-| Cross-agency aggregate   | 35%    | M6            |
-| Risk language (10-K NLP) | 20%    | M7            |
-| Earnings call divergence | 15%    | M8            |
-| Proxy escalation signals | 15%    | M9            |
-| Merger vertical risk     | 10%    | M10           |
-| PE ownership flag        | 5%     | M12           |
+**Parameters:**
 
-Missing components default to **0.0** — the scorer degrades gracefully if a module has not yet produced signals for an entity.
+| Parameter    | Type              | Description                                            |
+|--------------|-------------------|--------------------------------------------------------|
+| `output_dir` | `str` or `Path`   | Destination directory. Created (with parents) if absent. |
+| `db`         | `Session`         | SQLAlchemy session — read-only, no commit is issued.   |
+
+**Return value:**
+
+| Key             | Description                                         |
+|-----------------|-----------------------------------------------------|
+| `entities`      | Number of entities exported                         |
+| `alerts`        | Number of entities with a non-None alert level      |
+| `files_written` | Total files written (JSON + JS companions + HTML)   |
+
+**Viewing the dashboard:**
+
+```bash
+# Open directly from the filesystem (works in all modern browsers)
+open /path/to/output/index.html
+
+# Or serve it with Python's built-in HTTP server
+python -m http.server 8000 --directory /path/to/output
+# Then open http://localhost:8000
+```
+
+**Re-running is safe:** Export is fully idempotent. Files are written atomically (temp → rename) and stale entity files from previously-exported entities that are no longer in the database are automatically removed.
+
+For a full description of what each file contains and the technical design of the export, see [Output Layer (M14) in architecture.md](architecture.md#7-output-layer-m14).
 
 ---
 
-## 6. Generating Alerts for a Single Entity
+## 7. Generating the Weekly Email Digest
+
+`export_digest` produces a plaintext email body summarising new high-priority alerts and top sectors. The caller is responsible for SMTP delivery.
+
+```python
+from datetime import date, timedelta
+from cam.db.session import get_session
+from cam.output import export_digest
+
+# Summarise the last 7 days
+since_date = date.today() - timedelta(days=7)
+
+with get_session() as db:
+    body = export_digest(since_date, db=db)
+
+print(body)
+# Send via your preferred email library, e.g. smtplib or SendGrid
+```
+
+**Parameters:**
+
+| Parameter    | Type    | Description                                                     |
+|--------------|---------|-----------------------------------------------------------------|
+| `since_date` | `date`  | Alerts with `score_date >= since_date` are included.           |
+| `db`         | `Session` | SQLAlchemy session — read-only, no commit is issued.          |
+
+**What the digest includes:**
+
+- All critical and elevated alerts since `since_date`, each with up to two evidence snippets (≤ 120 chars each)
+- Top 5 NAICS sectors by average composite score (only sectors with ≥ 3 entities)
+- Period header and footer for email formatting
+
+**Typical cron integration:**
+
+```python
+# Run every Monday at 08:00 to cover the prior week
+import smtplib
+from email.message import EmailMessage
+from datetime import date, timedelta
+from cam.db.session import get_session
+from cam.output import export_digest
+
+since_date = date.today() - timedelta(days=7)
+with get_session() as db:
+    body = export_digest(since_date, db=db)
+
+msg = EmailMessage()
+msg["Subject"] = f"CAM Weekly Digest — {date.today()}"
+msg["From"] = "cam@example.com"
+msg["To"] = "analysts@example.com"
+msg.set_content(body)
+
+with smtplib.SMTP("localhost") as s:
+    s.send_message(msg)
+```
+
+---
+
+## 8. Interpreting Alert Levels
+
+| Level      | Threshold | Meaning                                     | Recommended Action                    |
+|------------|-----------|---------------------------------------------|---------------------------------------|
+| `watch`    | ≥ 0.40    | Worth monitoring; no immediate action       | Flag for weekly review                |
+| `elevated` | ≥ 0.65    | Elevated risk; analyst review warranted     | Assign analyst; cross-check filings   |
+| `critical` | ≥ 0.80    | Significant risk; regulatory action likely  | Escalate; consider regulatory referral|
+| *(none)*   | < 0.40    | Within normal operating range               | No action                             |
+
+Alerts only fire when the level **increases**. An entity that stays at `watch` for three weeks in a row generates exactly **one** alert — on the day it first crossed the 0.40 threshold.
+
+For the full score composition (component weights, signal types, and module sources), see [Score Composition in architecture.md](architecture.md#7-output-layer-m14).
+
+---
+
+## 9. Generating Alerts for a Single Entity
 
 ```python
 from datetime import date
@@ -220,7 +393,7 @@ with get_session() as db:
 
 ---
 
-## 7. Industry Benchmarking (PE vs. Non-PE)
+## 10. Industry Benchmarking (PE vs. Non-PE)
 
 The M12 PE/Bankruptcy Correlator can generate a citable comparison table across all NAICS sectors.
 
@@ -247,7 +420,7 @@ Only sectors with **more than 10 PE-owned entities** are included, per the stati
 
 ---
 
-## 8. Environment Setup
+## 11. Environment Setup
 
 Copy `.env.example` to `.env` and fill in the required values:
 
@@ -255,17 +428,19 @@ Copy `.env.example` to `.env` and fill in the required values:
 cp .env.example .env
 ```
 
-| Variable          | Required | Description                                         |
-|-------------------|----------|-----------------------------------------------------|
-| `DATABASE_URL`    | ✅       | PostgreSQL connection string                        |
-| `EDGAR_USER_AGENT`| ✅       | Your email address (SEC EDGAR requires it)          |
-| `REDIS_URL`       | ✗        | Default: `redis://localhost:6379/0`                 |
-| `S3_BUCKET`       | ✗        | Default: `cam-documents`                            |
-| `API_AUTH_TOKEN`  | ✗        | Required only for the REST API layer (M14)          |
+| Variable           | Required | Description                                              |
+|--------------------|----------|----------------------------------------------------------|
+| `DATABASE_URL`     | ✅       | PostgreSQL connection string                             |
+| `EDGAR_USER_AGENT` | ✅       | Your email address (SEC EDGAR requires it)               |
+| `REDIS_URL`        | ✗        | Default: `redis://localhost:6379/0`                      |
+| `S3_BUCKET`        | ✗        | Default: `cam-documents`                                 |
+| `API_AUTH_TOKEN`   | ✗        | Required only for the REST API layer (M14)               |
+
+When running via `docker-compose`, `DATABASE_URL`, `REDIS_URL`, and `S3_ENDPOINT` are automatically set to the container network addresses — you only need `.env` for `EDGAR_USER_AGENT` and any optional overrides.
 
 ---
 
-## 9. Running Tests
+## 12. Running Tests
 
 ```bash
 # All unit tests (no DB needed)


### PR DESCRIPTION
## Summary

- **`docs/architecture.md`** — Replaces the "Planned — not yet implemented" stub in §7 with the full M14 implementation: paired `.json`/`.js` file layout, `loadScript()` dashboard pattern (and why fetch() was dropped), atomic writes, stale file cleanup, ROW_NUMBER() query bounding, digest evidence snippets, and the score composition table.

- **`docs/usage.md`** — Adds two new sections and a Docker guide:
  - **§2 Docker usage** — `docker-compose run` for one-off pipeline commands, worker/beat logs, image rebuild
  - **§6 Exporting the Static Site Dashboard** — `export_static_site` call, parameter table, viewing instructions (file:// and http.server)
  - **§7 Generating the Weekly Email Digest** — `export_digest` call, parameter table, cron integration snippet
  - Updates Quick Start to include the export step; moves Score Composition detail to a reference to architecture.md; renumbers sections throughout

- **`CLAUDE.md`** — Adds a **Documentation Conventions** section so future sessions know: update `architecture.md` when the system design changes, update `usage.md` when operator-facing parameters or workflows change.

## Test plan

- [ ] Read through `docs/architecture.md` §7 and verify it matches the current implementation in `cam/output/exporter.py` and `cam/output/_templates.py`
- [ ] Read through `docs/usage.md` and verify code examples import from correct modules
- [ ] Confirm Docker commands in §2 match `docker-compose.yml` service names (`worker`, `beat`, `postgres`, `redis`, `minio`)
- [ ] Confirm the new CLAUDE.md section is concise and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)