### PR TITLE
Phase 2: wire seed bootstrap + all-sources-zero ingest guardrail

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -86,6 +86,12 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
+      - name: Seed entities (SEC EDGAR company_tickers)
+        run: python -m cam.entrypoint seed
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          EDGAR_USER_AGENT: ${{ secrets.EDGAR_USER_AGENT }}
+
       - name: Ingest all sources
         # Each source is attempted independently inside the entrypoint.
         # Exit code 1 if any source failed, but others still run.

--- a/cam/entrypoint.py
+++ b/cam/entrypoint.py
@@ -80,10 +80,12 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     logger.info("Ingest starting — sources=%s since=%s", sources, since)
 
     failures: list[str] = []
+    total_ingested = 0
 
     for source in sources:
         try:
-            _ingest_source(source, since, args)
+            count = _ingest_source(source, since, args)
+            total_ingested += count
         except Exception as exc:
             logger.error("Source '%s' failed: %s", source, exc, exc_info=True)
             failures.append(source)
@@ -92,12 +94,20 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         logger.error("Ingestion finished with failures: %s", failures)
         return 1
 
-    logger.info("Ingestion complete — all sources succeeded.")
+    if total_ingested == 0:
+        logger.error(
+            "Ingestion complete — all %d sources succeeded but ingested 0 records total. "
+            "This likely indicates upstream API contracts have broken.",
+            len(sources),
+        )
+        return 1
+
+    logger.info("Ingestion complete — all sources succeeded (%d records total).", total_ingested)
     return 0
 
 
-def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
-    """Dispatch a single source ingestion and log the result."""
+def _ingest_source(source: str, since: date, args: argparse.Namespace) -> int:
+    """Dispatch a single source ingestion and return the number of records ingested."""
     from cam.db.session import get_session
 
     if source == "osha":
@@ -124,6 +134,7 @@ def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
                 result = ingest_from_csv(csv_path, since_date=since, db=db)
             total_ingested += result.ingested
         logger.info("osha: %s records ingested", total_ingested)
+        return total_ingested
 
     elif source == "epa":
         from cam.ingestion.epa import ingest_echo_violations
@@ -131,6 +142,7 @@ def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
         with get_session() as db:
             count = ingest_echo_violations(since_date=since, db=db)
         logger.info("epa: %s records ingested", count)
+        return count
 
     elif source == "cfpb":
         from cam.ingestion.cfpb import ingest_complaints
@@ -138,6 +150,7 @@ def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
         with get_session() as db:
             count = ingest_complaints(since_date=since, db=db)
         logger.info("cfpb: %s records ingested", count)
+        return count
 
     elif source == "warn":
         from cam.ingestion.warn import ingest_all_states
@@ -145,6 +158,7 @@ def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
         with get_session() as db:
             summary = ingest_all_states(since_date=since, db=db)
         logger.info("warn: %s", summary)
+        return sum(r.ingested for r in summary)
 
     elif source == "edgar":
         from cam.ingestion.edgar import ingest_all_10k
@@ -152,6 +166,7 @@ def _ingest_source(source: str, since: date, args: argparse.Namespace) -> None:
         with get_session() as db:
             count = ingest_all_10k(since_date=since, entity_ids=None, db=db)
         logger.info("edgar: %s filings ingested", count)
+        return count
 
     else:
         raise ValueError(f"Unknown source: {source!r}")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,11 @@ docker-compose up -d
 # Apply database migrations
 DATABASE_URL=postgresql://cam:cam@localhost:5432/cam alembic upgrade head
 
+# Seed the entities table from SEC EDGAR (one-time on a fresh DB; idempotent)
+DATABASE_URL=postgresql://cam:cam@localhost:5432/cam \
+  EDGAR_USER_AGENT=you@example.com \
+  python -m cam.entrypoint seed
+
 # Ingest all regulatory sources (last 30 days by default)
 DATABASE_URL=postgresql://cam:cam@localhost:5432/cam \
   EDGAR_USER_AGENT=you@example.com \

--- a/tests/unit/test_entrypoint.py
+++ b/tests/unit/test_entrypoint.py
@@ -1,0 +1,68 @@
+"""Unit tests for the CLI entrypoint."""
+
+from __future__ import annotations
+
+import cam.entrypoint
+
+
+class TestIngestGuardrail:
+    """Tests for the guardrail that fails when all sources ingest 0 records."""
+
+    def test_all_sources_zero_returns_nonzero(self, monkeypatch):
+        """When every source ingests 0 records, exit code must be non-zero."""
+
+        def fake_ingest_source(source, since, args):
+            return 0
+
+        monkeypatch.setattr("cam.entrypoint._ingest_source", fake_ingest_source)
+        exit_code = cam.entrypoint.main(["ingest", "--source", "all", "--since", "2025-01-01"])
+        assert exit_code != 0
+
+    def test_one_source_with_records_returns_zero(self, monkeypatch):
+        """When at least one source ingests records, exit code must be 0."""
+
+        def fake_ingest_source(source, since, args):
+            return 5 if source == "osha" else 0
+
+        monkeypatch.setattr("cam.entrypoint._ingest_source", fake_ingest_source)
+        exit_code = cam.entrypoint.main(["ingest", "--source", "all", "--since", "2025-01-01"])
+        assert exit_code == 0
+
+    def test_exception_in_source_returns_nonzero(self, monkeypatch):
+        """When a source raises an exception, exit code must be non-zero."""
+
+        def fake_ingest_source(source, since, args):
+            if source == "epa":
+                raise ValueError("API down")
+            return 0
+
+        monkeypatch.setattr("cam.entrypoint._ingest_source", fake_ingest_source)
+        exit_code = cam.entrypoint.main(["ingest", "--source", "all", "--since", "2025-01-01"])
+        assert exit_code != 0
+
+    def test_single_source_zero_returns_nonzero(self, monkeypatch):
+        """When a single source (--source cfpb) ingests 0, exit code must be non-zero."""
+
+        def fake_ingest_source(source, since, args):
+            return 0
+
+        monkeypatch.setattr("cam.entrypoint._ingest_source", fake_ingest_source)
+        exit_code = cam.entrypoint.main(["ingest", "--source", "cfpb", "--since", "2025-01-01"])
+        assert exit_code != 0
+
+    def test_multiple_sources_with_records_returns_zero(self, monkeypatch):
+        """When multiple sources collectively ingest records, exit code must be 0."""
+
+        call_counts = {}
+
+        def fake_ingest_source(source, since, args):
+            call_counts[source] = call_counts.get(source, 0) + 1
+            return {"osha": 3, "epa": 2, "cfpb": 0, "warn": 0, "edgar": 0}.get(source, 0)
+
+        monkeypatch.setattr("cam.entrypoint._ingest_source", fake_ingest_source)
+        exit_code = cam.entrypoint.main(
+            ["ingest", "--source", "osha", "epa", "--since", "2025-01-01"]
+        )
+        assert exit_code == 0
+        assert call_counts.get("osha", 0) == 1
+        assert call_counts.get("epa", 0) == 1


### PR DESCRIPTION
## Summary

Phase 2 of the CAM revival plan: make a fresh deployment actually produce data, and make the pipeline notice when it silently stops producing data.

- **Seed bootstrap wired in** — the one-time `python -m cam.entrypoint seed` step (populates the entities table from SEC EDGAR `company_tickers.json`; idempotent) is now in the docs Quick Start and in the `pipeline.yml` ingest job, ordered **after migrations, before ingest**. Without seeding, EDGAR only fetches for entities already in the DB, so a fresh database is structurally guaranteed to produce nothing.
- **All-sources-zero guardrail** — `_ingest_source` now returns each source's record count and `_cmd_ingest` sums them. A run where every source *succeeds* but ingests **0 records total** now exits non-zero instead of reporting success — this is the "all upstream API contracts silently broke" failure mode that previously looked green.

Implementation ran as a Ringer swarm (two haiku workers on disjoint file sets); verdicts decided by executed checks written independently of the workers, both confirmed failing on the pre-change tree.

## Test plan

- [x] New `tests/unit/test_entrypoint.py` (5 tests): all-zero → non-zero exit; any records → 0; source raises → non-zero; single-source zero → non-zero; multi-source counts summed
- [x] Behavioral check executed against the real CLI with a monkeypatched source layer (4 cases pass)
- [x] `pipeline.yml` parsed and step order verified (migrate → seed → ingest, with `DATABASE_URL`/`EDGAR_USER_AGENT` env on the seed step)
- [x] Full unit suite: **768 passed, 12 skipped**
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)