### PR TITLE
Phase 3: live smoke-test tier + weekly scheduled smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,11 +19,17 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements*.txt"
+
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: uv pip install --system -r requirements-dev.txt
 
       - name: Run live smoke tests
         env:
-          DATABASE_URL: postgresql://smoke:smoke@localhost:5432/smoke
+          # No DB is touched — this dummy value only satisfies Settings validation.
+          DATABASE_URL: "sqlite:///:memory:"
           EDGAR_USER_AGENT: ${{ secrets.EDGAR_USER_AGENT || 'smoke@cam-project.org' }}
         run: python -m pytest tests/smoke -m live -v

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,29 @@
+# Weekly smoke test to detect upstream API/endpoint drift early.
+# Runs live tests against real endpoints. Per-source failures are expected signal,
+# not flakes — they indicate upstream changes we need to adapt to.
+name: CAM Weekly Smoke Test
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run live smoke tests
+        env:
+          DATABASE_URL: postgresql://smoke:smoke@localhost:5432/smoke
+          EDGAR_USER_AGENT: ${{ secrets.EDGAR_USER_AGENT || 'smoke@cam-project.org' }}
+        run: python -m pytest tests/smoke -m live -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=cam --cov-report=term-missing --cov-report=html --cov-report=xml -v"
+addopts = "--cov=cam --cov-report=term-missing --cov-report=html --cov-report=xml -v -m 'not live'"
 asyncio_mode = "auto"
+markers = [
+    "live: test hits a real external endpoint (network required). Excluded from the default run; select explicitly with -m live (see tests/smoke/).",
+]
 
 [tool.coverage.run]
 source = ["cam"]

--- a/tests/smoke/__init__.py
+++ b/tests/smoke/__init__.py
@@ -1,0 +1,2 @@
+"""Live smoke tests — hit real external endpoints. Excluded from the default
+run via the ``live`` marker; run with ``pytest tests/smoke -m live``."""

--- a/tests/smoke/_http.py
+++ b/tests/smoke/_http.py
@@ -1,0 +1,25 @@
+"""Shared HTTP helper for tests/smoke/.
+
+Wraps httpx with a bounded tenacity retry so a single transient blip
+(timeout, connection reset) doesn't turn a weekly smoke run red — a
+persistent failure (4xx/5xx, or repeated timeouts) still fails after the
+retry, which is the real drift signal these tests exist to surface.
+"""
+
+from __future__ import annotations
+
+import httpx
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+
+_TRANSIENT_EXCEPTIONS = (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError)
+_retry_transient = retry(
+    retry=retry_if_exception_type(_TRANSIENT_EXCEPTIONS),
+    stop=stop_after_attempt(2),
+    wait=wait_fixed(2),
+    reraise=True,
+)
+
+
+@_retry_transient
+def get_live(url: str, **kwargs) -> httpx.Response:
+    return httpx.get(url, **kwargs)

--- a/tests/smoke/test_cfpb.py
+++ b/tests/smoke/test_cfpb.py
@@ -1,15 +1,15 @@
 """Smoke tests for CFPB complaints bulk download."""
 
-import httpx
 import pytest
 
 from cam.config import get_settings
+from tests.smoke._http import get_live
 
 
 @pytest.mark.live
 def test_cfpb_bulk_reachable():
     """Check CFPB bulk download endpoint is reachable and returns ZIP data."""
     url = get_settings().cfpb_bulk_url
-    resp = httpx.get(url, headers={"Range": "bytes=0-3"}, follow_redirects=True, timeout=60)
+    resp = get_live(url, headers={"Range": "bytes=0-3"}, follow_redirects=True, timeout=60)
     assert resp.status_code in (200, 206)
     assert resp.content[:2] == b"PK"

--- a/tests/smoke/test_cfpb.py
+++ b/tests/smoke/test_cfpb.py
@@ -1,0 +1,15 @@
+"""Smoke tests for CFPB complaints bulk download."""
+
+import httpx
+import pytest
+
+from cam.config import get_settings
+
+
+@pytest.mark.live
+def test_cfpb_bulk_reachable():
+    """Check CFPB bulk download endpoint is reachable and returns ZIP data."""
+    url = get_settings().cfpb_bulk_url
+    resp = httpx.get(url, headers={"Range": "bytes=0-3"}, follow_redirects=True, timeout=60)
+    assert resp.status_code in (200, 206)
+    assert resp.content[:2] == b"PK"

--- a/tests/smoke/test_edgar.py
+++ b/tests/smoke/test_edgar.py
@@ -1,0 +1,24 @@
+"""Live smoke tests for SEC EDGAR integration."""
+
+import pytest
+
+
+@pytest.mark.live
+def test_company_tickers_reachable():
+    """Verify SEC EDGAR company_tickers.json endpoint is reachable and well-shaped."""
+    from cam.config import get_settings
+    from cam.ingestion.edgar import _get
+
+    url = get_settings().edgar_company_tickers_url
+    resp = _get(url)
+
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert isinstance(data, dict)
+    assert len(data) > 1000
+
+    sample = next(iter(data.values()))
+    assert "cik_str" in sample
+    assert "ticker" in sample
+    assert "title" in sample

--- a/tests/smoke/test_epa.py
+++ b/tests/smoke/test_epa.py
@@ -1,9 +1,9 @@
 """Smoke tests for EPA ECHO integration."""
 
-import httpx
 import pytest
 
 from cam.config import get_settings
+from tests.smoke._http import get_live
 
 
 @pytest.mark.live
@@ -11,7 +11,7 @@ def test_echo_bulk_enforcement_download_reachable():
     """Verify EPA ECHO bulk enforcement ZIP endpoint is reachable and returns valid ZIP."""
     url = get_settings().echo_bulk_zip_url
 
-    resp = httpx.get(
+    resp = get_live(
         url,
         headers={"Range": "bytes=0-3"},
         follow_redirects=True,

--- a/tests/smoke/test_epa.py
+++ b/tests/smoke/test_epa.py
@@ -1,0 +1,22 @@
+"""Smoke tests for EPA ECHO integration."""
+
+import httpx
+import pytest
+
+from cam.config import get_settings
+
+
+@pytest.mark.live
+def test_echo_bulk_enforcement_download_reachable():
+    """Verify EPA ECHO bulk enforcement ZIP endpoint is reachable and returns valid ZIP."""
+    url = get_settings().echo_bulk_zip_url
+
+    resp = httpx.get(
+        url,
+        headers={"Range": "bytes=0-3"},
+        follow_redirects=True,
+        timeout=60,
+    )
+
+    assert resp.status_code in (200, 206), f"Expected 200 or 206, got {resp.status_code}"
+    assert resp.content[:2] == b"PK", "Response does not start with ZIP magic bytes (PK)"

--- a/tests/smoke/test_osha.py
+++ b/tests/smoke/test_osha.py
@@ -1,0 +1,43 @@
+"""LIVE smoke tests for OSHA bulk enforcement CSV reachability."""
+
+from datetime import date
+
+import httpx
+import pytest
+
+from cam.ingestion.osha import _OSHA_BULK_BASE
+
+
+@pytest.mark.live
+def test_osha_bulk_csv_reachable():
+    """Verify that the OSHA bulk enforcement CSV is reachable for at least one recent year.
+
+    Tests the current year and prior year, since the current year's file may not be
+    published yet. At least one must be reachable.
+    """
+    today = date.today()
+    years_to_try = [today.year, today.year - 1]
+    statuses = []
+    urls = []
+
+    for year in years_to_try:
+        url = f"{_OSHA_BULK_BASE}/osha_{year}.csv"
+        urls.append(url)
+        status = None
+
+        try:
+            resp = httpx.head(url, follow_redirects=True, timeout=30)
+            status = resp.status_code
+        except httpx.RequestException:
+            try:
+                resp = httpx.get(url, headers={"Range": "bytes=0-3"}, timeout=30)
+                status = resp.status_code
+            except httpx.RequestException:
+                pass
+
+        statuses.append(status)
+
+    tried_info = ", ".join([f"{url} (status={status})" for url, status in zip(urls, statuses)])
+    assert any(status is not None and status < 400 for status in statuses), (
+        f"No reachable OSHA CSV found. Tried: {tried_info}"
+    )

--- a/tests/smoke/test_osha.py
+++ b/tests/smoke/test_osha.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from cam.ingestion.osha import _OSHA_BULK_BASE
+from tests.smoke._http import get_live
 
 
 @pytest.mark.live
@@ -13,31 +14,25 @@ def test_osha_bulk_csv_reachable():
     """Verify that the OSHA bulk enforcement CSV is reachable for at least one recent year.
 
     Tests the current year and prior year, since the current year's file may not be
-    published yet. At least one must be reachable.
+    published yet. At least one must be reachable. Uses a single ranged GET per year
+    (rather than HEAD-then-GET-on-exception) so a non-2xx/3xx HEAD response can't
+    silently skip the GET probe.
     """
     today = date.today()
     years_to_try = [today.year, today.year - 1]
-    statuses = []
+    statuses: list[int | None] = []
     urls = []
 
     for year in years_to_try:
         url = f"{_OSHA_BULK_BASE}/osha_{year}.csv"
         urls.append(url)
-        status = None
-
         try:
-            resp = httpx.head(url, follow_redirects=True, timeout=30)
-            status = resp.status_code
+            resp = get_live(url, headers={"Range": "bytes=0-3"}, follow_redirects=True, timeout=30)
+            statuses.append(resp.status_code)
         except httpx.RequestException:
-            try:
-                resp = httpx.get(url, headers={"Range": "bytes=0-3"}, timeout=30)
-                status = resp.status_code
-            except httpx.RequestException:
-                pass
+            statuses.append(None)
 
-        statuses.append(status)
-
-    tried_info = ", ".join([f"{url} (status={status})" for url, status in zip(urls, statuses)])
+    tried_info = ", ".join(f"{url} (status={status})" for url, status in zip(urls, statuses))
     assert any(status is not None and status < 400 for status in statuses), (
         f"No reachable OSHA CSV found. Tried: {tried_info}"
     )

--- a/tests/smoke/test_warn.py
+++ b/tests/smoke/test_warn.py
@@ -1,0 +1,31 @@
+"""
+Live smoke tests for WARN Act state sources.
+
+These tests verify that all configured state source URLs are accessible and
+return successful responses. Per-state test nodes surface which state feeds
+have drifted independently.
+"""
+
+import httpx
+import pytest
+
+from cam.ingestion.warn.state_urls import STATE_CONFIGS
+
+
+@pytest.mark.live
+@pytest.mark.parametrize("code", sorted(STATE_CONFIGS))
+def test_warn_state_url_accessible(code: str) -> None:
+    """
+    Verify that each WARN state source URL is accessible.
+
+    Each state is a separate test node so that failures in individual
+    state feeds are immediately visible and don't mask other states.
+    """
+    cfg = STATE_CONFIGS[code]
+    resp = httpx.get(
+        cfg.url,
+        headers={"User-Agent": "Mozilla/5.0 (compatible; CAM-smoke/1.0)"},
+        follow_redirects=True,
+        timeout=30,
+    )
+    assert resp.status_code < 400, f"State {code} failed: {cfg.url} returned {resp.status_code}"

--- a/tests/smoke/test_warn.py
+++ b/tests/smoke/test_warn.py
@@ -6,14 +6,32 @@ return successful responses. Per-state test nodes surface which state feeds
 have drifted independently.
 """
 
-import httpx
 import pytest
 
 from cam.ingestion.warn.state_urls import STATE_CONFIGS
+from tests.smoke._http import get_live
+
+# States with a known, already-documented outage (see the comments on their
+# StateConfig in cam/ingestion/warn/state_urls.py) are xfail so the weekly
+# smoke run stays a useful signal for NEW drift rather than being
+# permanently red on issues already tracked. Do not add a state here just
+# because it failed once — that suppresses the exact drift this suite exists
+# to catch. Only add it once there's a known, documented root cause.
+_KNOWN_BROKEN = {
+    "CA": "CA switched CSV->XLSX in early 2026; old warn_report.csv URL 404s until XLSX ingestion ships",
+    "MI": "MI blocks non-browser clients with a 403 from its Akamai WAF as of March 2026",
+}
+
+_PARAMS = [
+    pytest.param(code, marks=pytest.mark.xfail(reason=_KNOWN_BROKEN[code], strict=False))
+    if code in _KNOWN_BROKEN
+    else code
+    for code in sorted(STATE_CONFIGS)
+]
 
 
 @pytest.mark.live
-@pytest.mark.parametrize("code", sorted(STATE_CONFIGS))
+@pytest.mark.parametrize("code", _PARAMS)
 def test_warn_state_url_accessible(code: str) -> None:
     """
     Verify that each WARN state source URL is accessible.
@@ -22,7 +40,7 @@ def test_warn_state_url_accessible(code: str) -> None:
     state feeds are immediately visible and don't mask other states.
     """
     cfg = STATE_CONFIGS[code]
-    resp = httpx.get(
+    resp = get_live(
         cfg.url,
         headers={"User-Agent": "Mozilla/5.0 (compatible; CAM-smoke/1.0)"},
         follow_redirects=True,


### PR DESCRIPTION
## Summary

Phase 3 of the CAM revival plan: a network-backed smoke tier that detects upstream API/endpoint drift — the failure mode the fully-mocked unit suite is structurally blind to (this is exactly how M2–M4's live contract breaks went undetected until Phase 1's review).

- **New `live` pytest marker** — registered in `pyproject.toml`, `-m 'not live'` added to `addopts` so live tests are excluded from every default run and selected explicitly with `-m live`.
- **`tests/smoke/`** — one reachability + shape test per source:
  - `test_edgar.py` — fetches `company_tickers.json` via the real `_get` helper, asserts shape (>1000 entries, expected keys)
  - `test_cfpb.py` / `test_epa.py` — cheap ranged GET (first 4 bytes) against the bulk ZIP endpoints, asserts ZIP magic bytes — never downloads the full ~1GB/large files
  - `test_osha.py` — probes the two most recent years' bulk CSVs, tolerates the current year not being published yet
  - `test_warn.py` — parametrized **per state** over `STATE_CONFIGS` so each state feed fails independently instead of masking others
- **`.github/workflows/smoke.yml`** — weekly (Mon 07:00 UTC) + `workflow_dispatch`, runs `pytest tests/smoke -m live -v`. A red run is the drift alert.

Built via a Ringer swarm (6 haiku workers in parallel, one per file), each gated by an executed check I wrote independently of the workers (collect under `-m live`, deselected by the default run, references the real settings field/module constant) — all 6 passed on first attempt.

## Test plan

- [x] `ruff check` / `ruff format` clean on all new files
- [x] Default suite unaffected: `763 passed, 12 skipped, 12 deselected` (the 12 deselected are exactly the new smoke tests — confirms zero live calls in normal runs, no regression)
- [x] Live run executed against real endpoints today — confirms the tier actually works and surfaces real drift:
  - reachable: CFPB, EDGAR, EPA, WARN NY/PA/TX
  - **drifted (P4 targets)**: OSHA bulk CSV (both recent years), WARN CA/FL/IL/MI/OH

🤖 Generated with [Claude Code](https://claude.com/claude-code)